### PR TITLE
[riscv32] Use clang instead of gcc

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -101,7 +101,7 @@ feature(
 
 feature(
     name = "symbol_garbage_collection",
-    enabled = False,
+    enabled = True,
     flag_sets = [
         flag_set(
             actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,

--- a/features/embedded/BUILD.bazel
+++ b/features/embedded/BUILD.bazel
@@ -1,0 +1,100 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//config:features.bzl",
+    "CPP_ALL_COMPILE_ACTIONS",
+    "C_ALL_COMPILE_ACTIONS",
+    "LD_ALL_ACTIONS",
+    "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+feature(
+    name = "runtime_type_information",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable RTTI
+                        "-fno-rtti",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
+    name = "exceptions",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable Exceptions
+                        "-fno-exceptions",
+                        "-fno-non-call-exceptions",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
+    name = "cc_constructor_destructor",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Indicate that this program may not neccesarily be able to use standard system calls
+                        "-ffreestanding",
+                        # Instantiate global variables only once
+                        "-fno-common",
+                        # Emits guards against functions that have references to local array definitions
+                        "[STACK_PROTECTOR]",
+                    ],
+                ),
+            ],
+        ),
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Disable teardown/destructors for static variables
+                        "-fno-use-cxa-atexit",
+                        # Disable threadsafe statics
+                        "-fno-threadsafe-statics",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature_set(
+    name = "embedded",
+    feature = [
+        "runtime_type_information",
+        "exceptions",
+        "cc_constructor_destructor",
+    ],
+    substitutions = {
+        "[STACK_PROTECTOR]": "-fstack-protector-strong",
+    },
+)

--- a/platforms/riscv32/devices.bzl
+++ b/platforms/riscv32/devices.bzl
@@ -18,6 +18,7 @@ DEVICES = [
             "ABI": "ilp32",
             "CMODEL": "medany",
             "ENDIAN": "little",
+            "[STACK_PROTECTOR]": "",
         },
     ),
 ]

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -34,10 +34,33 @@ feature(
     ],
 )
 
+feature(
+    name = "fastbuild",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Os",
+                        "-g",
+                    ],
+                ),
+            ],
+        ),
+    ],
+    provides = ["compilation_mode"],
+)
+
 feature_set(
     name = "rv32imc",
-    base = ["//features/common"],
+    base = [
+        "//features/common",
+        "//features/embedded",
+    ],
     feature = [
         ":architecture",
+        ":fastbuild",
     ],
 )

--- a/toolchains/lowrisc_rv32imcb/BUILD.bazel
+++ b/toolchains/lowrisc_rv32imcb/BUILD.bazel
@@ -8,13 +8,11 @@ load("//platforms/riscv32:devices.bzl", "DEVICES")
 package(default_visibility = ["//visibility:public"])
 
 SYSTEM_INCLUDE_PATHS = [
-    "external/lowrisc_rv32imcb_files/lib/gcc/riscv32-unknown-elf/10.2.0/include",
-    "external/lowrisc_rv32imcb_files/lib/gcc/riscv32-unknown-elf/10.2.0/include-fixed",
+    "external/lowrisc_rv32imcb_files/lib/clang/13.0.1/include",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0/backward",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0/riscv32-unknown-elf",
-    "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/sys-include",
 ]
 
 filegroup(
@@ -40,7 +38,7 @@ filegroup(
     tools = {
         "ar": "wrappers/ar",
         "cpp": "wrappers/cpp",
-        "gcc": "wrappers/gcc",
+        "gcc": "wrappers/clang",
         "gcov": "wrappers/gcov",
         "ld": "wrappers/ld",
         "nm": "wrappers/nm",

--- a/toolchains/lowrisc_rv32imcb/wrappers/BUILD
+++ b/toolchains/lowrisc_rv32imcb/wrappers/BUILD
@@ -6,6 +6,7 @@ filegroup(
     name = "all",
     srcs = [
         "ar",
+        "clang",
         "cpp",
         "gcc",
         "gcov",

--- a/toolchains/lowrisc_rv32imcb/wrappers/clang
+++ b/toolchains/lowrisc_rv32imcb/wrappers/clang
@@ -1,0 +1,1 @@
+driver.sh


### PR DESCRIPTION
Signed-off-by: Chris Frantz <cfrantz@google.com>