### PR TITLE
Add missing sha256

### DIFF
--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -8,5 +8,6 @@ def lowrisc_rv32imcb_repos():
     compiler_repository(
         name = "lowrisc_rv32imcb_files",
         url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20220524-1/lowrisc-toolchain-rv32imcb-20220524-1.tar.xz",
+        sha256 = "a4579324083577a0f20cf4b03d11c6a7563265ced0ed2f7b51c3722d80fd24c4",
         strip_prefix = "lowrisc-toolchain-rv32imcb-20220524-1",
     )


### PR DESCRIPTION
The SHA of the lowrisc toolchain archive was missing causing this to be incompatible in airgapped mode.

Signed-off-by: Timothy Trippel <ttrippel@google.com>