### PR TITLE
Eliminate basename/dirname in favor of bash builtins

### DIFF
--- a/toolchains/cc65/wrappers/driver.sh
+++ b/toolchains/cc65/wrappers/driver.sh
@@ -3,8 +3,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-PROG=$(basename "$0")
-DRIVER_DIR=$(dirname "$0")
+PROG=${0##*/}
+DRIVER_DIR=${0%/*}
 TOOLCHAIN="cc65_files"
 
 ARGS=()

--- a/toolchains/gcc_mxe_mingw64/wrappers/driver.sh
+++ b/toolchains/gcc_mxe_mingw64/wrappers/driver.sh
@@ -3,8 +3,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-PROG=$(basename "$0")
-DRIVER_DIR=$(dirname "$0")
+PROG=${0##*/}
+DRIVER_DIR=${0%/*}
 MXE="gcc_mxe_mingw64_files"
 VERSION="11.3.0"
 PREFIX="x86_64-w64-mingw32.shared"

--- a/toolchains/lowrisc_rv32imcb/wrappers/driver.sh
+++ b/toolchains/lowrisc_rv32imcb/wrappers/driver.sh
@@ -3,17 +3,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-PROG=$(basename "$0")
-DRIVER_DIR=$(dirname "$0")
+PROG=${0##*/}
 TOOLCHAIN="lowrisc_rv32imcb_files"
 PREFIX="riscv32-unknown-elf"
 
 ARGS=()
 POSTARGS=()
-case "${PROG}" in
-    gcc)
-        ;;
-esac
 
 exec "external/${TOOLCHAIN}/bin/${PREFIX}-${PROG}" \
     "${ARGS[@]}" \


### PR DESCRIPTION
Some environments appear to remove even the standard binary dirs (like `/usr/bin`) from PATH.  Use bash built-ins to get the basename and dirname.

Signed-off-by: Chris Frantz <cfrantz@google.com>