### PR TITLE
Add support for the CHERI-LLVM toolchain for RV32 baremetal apps

### DIFF
--- a/config/registration.bzl
+++ b/config/registration.bzl
@@ -4,6 +4,7 @@
 
 load("@crt//toolchains/gcc_arm_none_eabi:repository.bzl", "gcc_arm_none_eabi_repos")
 load("@crt//toolchains/lowrisc_rv32imcb:repository.bzl", "lowrisc_rv32imcb_repos")
+load("@crt//toolchains/cheri_llvm:repository.bzl", "cheri_llvm_repos")
 load("@crt//toolchains/gcc_mxe_mingw64:repository.bzl", "gcc_mxe_mingw64_repos")
 load("@crt//toolchains/cc65:repository.bzl", "cc65_repos")
 
@@ -11,6 +12,7 @@ def crt_register_toolchains(
         arm = False,
         m6502 = False,
         riscv32 = False,
+        cheri_llvm = False,
         win64 = False):
     native.register_execution_platforms("@local_config_platform//:host")
     if arm:
@@ -27,6 +29,11 @@ def crt_register_toolchains(
         lowrisc_rv32imcb_repos()
         native.register_execution_platforms("@crt//platforms/riscv32:all")
         native.register_toolchains("@crt//toolchains/lowrisc_rv32imcb:all")
+
+    if cheri_llvm:
+        cheri_llvm_repos()
+        native.register_execution_platforms("@crt//platforms/riscv32-cheri:all")
+        native.register_toolchains("@crt//toolchains/cheri_llvm:all")
 
     if win64:
         gcc_mxe_mingw64_repos()

--- a/platforms/riscv32-cheri/BUILD.bazel
+++ b/platforms/riscv32-cheri/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//config:execution.bzl", "exec_config")
+
+platform(
+    name = "riscv32-cheri",
+    constraint_values = [
+        "@platforms//cpu:riscv32",
+        "//platforms/riscv32-cheri/extension:cheri",
+    ],
+)

--- a/platforms/riscv32-cheri/devices.bzl
+++ b/platforms/riscv32-cheri/devices.bzl
@@ -1,0 +1,20 @@
+load("//config:device.bzl", "device_config")
+
+DEVICES = [
+    device_config(
+        name = "riscv32-cheri",
+        architecture = "rv32imcxcheri",
+        feature_set = "//platforms/riscv32-cheri/features:rv32imcxcheri",
+        constraints = [
+            "@platforms//cpu:riscv32",
+            "//platforms/riscv32-cheri/extension:cheri",
+        ],
+        substitutions = {
+            "ARCHITECTURE": "rv32imcxcheri",
+            "ABI": "il32pc64",
+            "CMODEL": "medany",
+            "ENDIAN": "little",
+            "[STACK_PROTECTOR]": "",
+        },
+    ),
+]

--- a/platforms/riscv32-cheri/extension/BUILD.bazel
+++ b/platforms/riscv32-cheri/extension/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+constraint_setting(name = "extension")
+
+constraint_value(
+    name = "cheri",
+    constraint_setting = ":extension",
+)

--- a/platforms/riscv32-cheri/features/BUILD.bazel
+++ b/platforms/riscv32-cheri/features/BUILD.bazel
@@ -25,7 +25,9 @@ feature(
                         "-mcmodel=CMODEL",
                         "-mENDIAN-endian",
                         "--target=riscv32-unknown-elf",
-                        "-Wl,-Lexternal/cheri_llvm_files/sdk/baremetal/baremetal-riscv32-purecap/riscv32-unknown-elf/lib/",
+                        "-mno-relax",
+                        # tell the loader where the base libraries are
+                        "-Lexternal/cheri_llvm_files/sdk/baremetal/baremetal-riscv32-purecap/riscv32-unknown-elf/lib/",
                     ],
                 ),
             ],

--- a/platforms/riscv32-cheri/features/BUILD.bazel
+++ b/platforms/riscv32-cheri/features/BUILD.bazel
@@ -1,0 +1,65 @@
+load(
+    "//config:features.bzl",
+    "CPP_ALL_COMPILE_ACTIONS",
+    "C_ALL_COMPILE_ACTIONS",
+    "LD_ALL_ACTIONS",
+    "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+feature(
+    name = "architecture",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS + LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-march=ARCHITECTURE",
+                        "-mabi=ABI",
+                        "-mcmodel=CMODEL",
+                        "-mENDIAN-endian",
+                        "--target=riscv32-unknown-elf",
+                        "-Wl,-Lexternal/cheri_llvm_files/sdk/baremetal/baremetal-riscv32-purecap/riscv32-unknown-elf/lib/",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
+    name = "fastbuild",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Os",
+                        "-g",
+                    ],
+                ),
+            ],
+        ),
+    ],
+    provides = ["compilation_mode"],
+)
+
+feature_set(
+    name = "rv32imcxcheri",
+    base = [
+        "//features/common",
+        "//features/embedded",
+    ],
+    feature = [
+        ":architecture",
+        ":fastbuild",
+    ],
+)

--- a/toolchains/cheri_llvm/BUILD.bazel
+++ b/toolchains/cheri_llvm/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//config:compiler.bzl", "setup")
+load("//platforms/riscv32-cheri:devices.bzl", "DEVICES")
+
+package(default_visibility = ["//visibility:public"])
+
+SYSTEM_INCLUDE_PATHS = [
+    "external/cheri_llvm_files/sdk/lib/clang/13.0.0/include",
+    "external/cheri_llvm_files/sdk/baremetal/baremetal-riscv32-purecap/riscv32-unknown-elf/include/",
+]
+
+filegroup(
+    name = "compiler_components",
+    srcs = [
+        "//toolchains/cheri_llvm/wrappers:all",
+        "@cheri_llvm_files//:all",
+    ],
+)
+
+[setup(
+    name = device.name,
+    architecture = device.architecture,
+    artifact_naming = device.artifact_naming,
+    compiler_components = ":compiler_components",
+    constraints = device.constraints,
+    feature_set = device.feature_set,
+    include_directories = SYSTEM_INCLUDE_PATHS,
+    params = {
+        "compiler": "clang",
+    },
+    substitutions = device.substitutions,
+    tools = {
+        "ar":      "wrappers/ar",
+        "cpp":     "wrappers/cpp",
+        "gcc":     "wrappers/clang",
+        "ld":      "wrappers/ld",
+        "nm":      "wrappers/nm",
+        "objcopy": "wrappers/objcopy",
+        "objdump": "wrappers/objdump",
+        "strip":   "wrappers/strip",
+    },
+) for device in DEVICES]

--- a/toolchains/cheri_llvm/archive/BUILD.bazel
+++ b/toolchains/cheri_llvm/archive/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/toolchains/cheri_llvm/archive/README.md
+++ b/toolchains/cheri_llvm/archive/README.md
@@ -1,0 +1,23 @@
+### Instructions for building the CHERI-LLVM toolchain archive for purecap riscv32
+
+This will use [cheribuild](https://github.com/CTSRD-CHERI/cheribuild) to build
+the CHERI-LLVM RISC-V 32bit "purecap" toolchain for embedded development.
+By default, the sources and toolchain will be fetched and built in `~/cheri/`.
+This can be changed using the `--source-root`, `--output-root`, `--build-root`,
+and `--tools-root` arguments. `-d` ensures required steps are executed (i.e.
+builds LLVM & Clang before compiling the libraries). `-j` controls the number
+of threads to be used for compilation.
+
+Clone the cheribuild repository anywhere (its directory will not be used for building), then:
+
+`./cheribuild.py newlib-baremetal-riscv32-purecap -d` (for libc, libm, libg)  
+`./cheribuild.py compiler-rt-builtins-baremetal-riscv32-purecap -d` (for builtins)
+
+Then `cd` to wherever the sdk folder is (`~/cheri/output/` by default,
+or within either of the directories pointed to when passing
+`--tool-root` or `--output-root`) and tar the `sdk` folder:  
+`tar -cvzf cheri_llvm_sdk.tar.gz sdk/`
+
+Lastly, copy `cheri_llvm_sdk.tar.gz` to this folder. The name must match the
+filename in the `archive` field in `../repository.bzl`
+

--- a/toolchains/cheri_llvm/repository.bzl
+++ b/toolchains/cheri_llvm/repository.bzl
@@ -1,0 +1,8 @@
+load("@crt//config:repo.bzl", "compiler_repository")
+
+def cheri_llvm_repos():
+    compiler_repository(
+        name = "cheri_llvm_files",
+        archive = "@crt//toolchains/cheri_llvm/archive:cheri_llvm_sdk.tar.gz",
+        exports = ["sdk/bin/**"],
+    )

--- a/toolchains/cheri_llvm/wrappers/BUILD
+++ b/toolchains/cheri_llvm/wrappers/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*"]))
+
+filegroup(
+    name = "all",
+    srcs = [
+        "ar",
+        "clang",
+        "cpp",
+        "ld",
+        "nm",
+        "objcopy",
+        "objdump",
+        "strip",
+    ],
+)

--- a/toolchains/cheri_llvm/wrappers/ar
+++ b/toolchains/cheri_llvm/wrappers/ar
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/clang
+++ b/toolchains/cheri_llvm/wrappers/clang
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/cpp
+++ b/toolchains/cheri_llvm/wrappers/cpp
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/driver.sh
+++ b/toolchains/cheri_llvm/wrappers/driver.sh
@@ -1,0 +1,13 @@
+#!/bin/bash --norc
+
+PROG=${0##*/}
+TOOLCHAIN="cheri_llvm_files"
+VERSION="13.0.0"
+
+ARGS=()
+POSTARGS=()
+
+exec "external/${TOOLCHAIN}/sdk/bin/${PROG}" \
+    "${ARGS[@]}" \
+    "$@"\
+    "${POSTARGS[@]}"

--- a/toolchains/cheri_llvm/wrappers/ld
+++ b/toolchains/cheri_llvm/wrappers/ld
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/nm
+++ b/toolchains/cheri_llvm/wrappers/nm
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/objcopy
+++ b/toolchains/cheri_llvm/wrappers/objcopy
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/objdump
+++ b/toolchains/cheri_llvm/wrappers/objdump
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/cheri_llvm/wrappers/strip
+++ b/toolchains/cheri_llvm/wrappers/strip
@@ -1,0 +1,1 @@
+driver.sh


### PR DESCRIPTION
At the moment there is no toolchain archive available for the CHERI-LLVM toolchain, so instructions to create the archive are included in `toolchains/cheri_llvm/archive/README.md`.