### PR TITLE
Update lowRISC toolchain version

### DIFF
--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def lowrisc_rv32imcb_repos():
     compiler_repository(
         name = "lowrisc_rv32imcb_files",
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20220524-1/lowrisc-toolchain-rv32imcb-20220524-1.tar.xz",
-        sha256 = "a4579324083577a0f20cf4b03d11c6a7563265ced0ed2f7b51c3722d80fd24c4",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-20220524-1",
+        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20221129-1/lowrisc-toolchain-rv32imcb-20221129-1.tar.xz",
+        sha256 = "1258433069e65da8e12fd2d697fc8d1b9d68bfc2dc20f269e58fabb2e30509f0",
+        strip_prefix = "lowrisc-toolchain-rv32imcb-20221129-1",
     )


### PR DESCRIPTION
The new toolchain version includes:

- Support for the `.option noguards`.
- Fix for the jump guards hardening.