### PR TITLE
Correct `includes` for build stamping

### DIFF
--- a/config/compiler.bzl
+++ b/config/compiler.bzl
@@ -20,11 +20,11 @@ PARAM_DEFAULTS = {
     "abi_libc_version": "unknown",
 }
 
-def listify_flags(flag, args = [], spaces_in_args=False):
+def listify_flags(flag, args = [], spaces_in_args = False):
     args = [flag.format(p) for p in args]
     value = "|".join(args)
     if not spaces_in_args:
-        value = value.replace(' ', '|')
+        value = value.replace(" ", "|")
     return value
 
 def union(*args, **kwargs):

--- a/config/features.bzl
+++ b/config/features.bzl
@@ -44,6 +44,8 @@ C_COMPILE_NO_ASM_ACTIONS = [
 
 LD_ALL_ACTIONS = [
     ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
 ]
 
 FeatureSetInfo = provider(fields = ["features", "subst"])

--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -28,6 +28,14 @@ feature(
                         "[SYSTEM_INCLUDES]",
                     ],
                 ),
+                flag_group(
+                    expand_if_available = "includes",
+                    flags = [
+                        "-include",
+                        "%{includes}",
+                    ],
+                    iterate_over = "includes",
+                ),
             ],
         ),
     ],


### PR DESCRIPTION
The `includes` feature was not expanding bazel-provided `includes`.  These `includes` are used to set build metadata for C compilation units.