### PR TITLE
Add a `win32` compiler configuration

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,8 @@ release(
     name = "release",
     artifacts = {
         "@cc65_src//:cc65-binaries": "cc65 compiler",
-        "@mxe_src//:mxe-binaries": "MXE mingw64 compiler",
+        "@mxe_src//:mxe-binaries-win32": "MXE Win32 compiler",
+        "@mxe_src//:mxe-binaries-win64": "MXE Win64 compiler",
         "@qemu_src//:qemu-binaries": "QEMU system emulator",
     },
     env = {
@@ -23,7 +24,10 @@ release(
         SHA256=${DIGEST[cc65-binaries.tar.xz]} envsubst \
                 <toolchains/cc65/repository.bzl.template \
                 >toolchains/cc65/repository.bzl
-        SHA256=${DIGEST[mxe-binaries.tar.xz]} envsubst \
+        SHA256=${DIGEST[mxe-binaries-win32.tar.xz]} envsubst \
+                <toolchains/gcc_mxe_mingw32/repository.bzl.template \
+                >toolchains/gcc_mxe_mingw32/repository.bzl
+        SHA256=${DIGEST[mxe-binaries-win64.tar.xz]} envsubst \
                 <toolchains/gcc_mxe_mingw64/repository.bzl.template \
                 >toolchains/gcc_mxe_mingw64/repository.bzl
         SHA256=${DIGEST[qemu-binaries.tar.xz]} envsubst \

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ release(
         # Update modified hashes.
         git commit -m "Update tags and hashes for ${RELEASE_TAG}" \
                 toolchains/cc65/repository.bzl \
+                toolchains/gcc_mxe_mingw32/repository.bzl \
                 toolchains/gcc_mxe_mingw64/repository.bzl \
                 third_party/qemu/repos.bzl
 

--- a/config/registration.bzl
+++ b/config/registration.bzl
@@ -4,6 +4,7 @@
 
 load("@crt//toolchains/gcc_arm_none_eabi:repository.bzl", "gcc_arm_none_eabi_repos")
 load("@crt//toolchains/lowrisc_rv32imcb:repository.bzl", "lowrisc_rv32imcb_repos")
+load("@crt//toolchains/gcc_mxe_mingw32:repository.bzl", "gcc_mxe_mingw32_repos")
 load("@crt//toolchains/gcc_mxe_mingw64:repository.bzl", "gcc_mxe_mingw64_repos")
 load("@crt//toolchains/cc65:repository.bzl", "cc65_repos")
 
@@ -11,6 +12,7 @@ def crt_register_toolchains(
         arm = False,
         m6502 = False,
         riscv32 = False,
+        win32 = False,
         win64 = False):
     native.register_execution_platforms("@local_config_platform//:host")
     if arm:
@@ -27,6 +29,11 @@ def crt_register_toolchains(
         lowrisc_rv32imcb_repos()
         native.register_execution_platforms("@crt//platforms/riscv32:all")
         native.register_toolchains("@crt//toolchains/lowrisc_rv32imcb:all")
+
+    if win32:
+        gcc_mxe_mingw32_repos()
+        native.register_execution_platforms("@crt//platforms/x86_32:all")
+        native.register_toolchains("@crt//toolchains/gcc_mxe_mingw32:all")
 
     if win64:
         gcc_mxe_mingw64_repos()

--- a/deps.bzl
+++ b/deps.bzl
@@ -4,7 +4,7 @@
 
 load("//third_party/bazel:deps.bzl", "bazel_deps")
 
-def crt_deps(windows_disk_image=None):
+def crt_deps(windows_disk_image = None):
     bazel_deps()
     if windows_disk_image:
         native.bind(

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -5,8 +5,8 @@
 load(
     "//config:features.bzl",
     "CPP_ALL_COMPILE_ACTIONS",
-    "C_ALL_COMPILE_ACTIONS",
     "CPP_COMPILE_NO_ASM_ACTIONS",
+    "C_ALL_COMPILE_ACTIONS",
     "C_COMPILE_NO_ASM_ACTIONS",
     "LD_ALL_ACTIONS",
     "feature",
@@ -70,7 +70,7 @@ feature(
                 ),
             ],
         ),
-    ]
+    ],
 )
 
 feature(

--- a/platforms/x86_32/BUILD.bazel
+++ b/platforms/x86_32/BUILD.bazel
@@ -1,0 +1,57 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//config:execution.bzl", "exec_config")
+
+platform(
+    name = "win32",
+    constraint_values = [
+        "@platforms//cpu:x86_32",
+        "@platforms//os:windows",
+    ],
+)
+
+# FIXME: this is an exact copy of //platforms/x86_64:qemu_windows.  This
+# should probably instead reference a disk image that can be an old
+# version of 32-bit windows.
+exec_config(
+    name = "qemu_windows",
+    data = ["//external:windows_disk_image"],
+    params = [
+        "-M pc",
+        "-m {memory}",
+        "{nographic}",
+        "{monitor}",
+        "-usb -device usb-tablet",
+        "-hda {disk_image_snapshot}",
+        # Writing to qemu's vvfat filesystem is slow and unreliable.
+        # We set up windows COM ports to capture stdout, stderr and
+        # the program's exit code.
+        "-drive file=fat:rw:$PWD/exclude_external,format=raw",
+        "-chardev file,id=com3,path={exitcode}",
+        "-serial file:{stdout}",
+        "-serial file:{stderr}",
+        "-device pci-serial,chardev=com3",
+    ],
+    preparation = "windows",
+    program = "@qemu//:qemu-system-x86_64",
+    substitutions = {
+        "disk_image": "$(location //external:windows_disk_image)",
+        # You should only use quick_kill if you're using a disk_image_snapshot
+        # for the disk image.  Snapshots are discarded on every run, so an
+        # improper shutdown doesn't matter.
+        "quick_kill": "true",
+        "shutdown": "shutdown /p",
+        #"shutdown": "",
+        "memory": "4G",
+        #"nographic": "-nographic",
+        "nographic": "",
+        "monitor": "-monitor null",
+        "stdout": "/tmp/stdout.$$",
+        "stderr": "/tmp/stderr.$$",
+        "exitcode": "/tmp/exitcode.$$",
+    },
+)

--- a/platforms/x86_32/windows.bzl
+++ b/platforms/x86_32/windows.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//config:device.bzl", "device_config")
+
+DEVICES = [
+    device_config(
+        name = "pc-win32",
+        architecture = "x86_32",
+        feature_set = "//features/windows",
+        constraints = [
+            "@platforms//cpu:x86_32",
+            "@platforms//os:windows",
+        ],
+        artifact_naming = [
+            "//features/windows:exe",
+            "//features/windows:dll",
+        ],
+    ),
+]

--- a/rules/pkg_win.bzl
+++ b/rules/pkg_win.bzl
@@ -3,11 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:transition.bzl", "platform_rule")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+
+def _get_toolchain_dir(cc_toolchain):
+    workspace = [f for f in cc_toolchain.all_files.to_list() if f.basename == "WORKSPACE"]
+    if not workspace:
+        fail("Could not find the WORKSPACE of the cc_toolchain")
+    return workspace[0]
 
 def _pkg_win_impl(ctx):
     out = ctx.actions.declare_file(ctx.attr.name + ".zip")
+    if ctx.attr.platform == "@crt//platforms/x86_64:win64":
+        target = "win64"
+    elif ctx.attr.platform == "@crt//platforms/x86_32:win32":
+        target = "win32"
+    else:
+        fail("Unknown platform:", ctx.attr.platform)
+
+    cc_toolchain = find_cc_toolchain(ctx).cc
+    mxe = _get_toolchain_dir(cc_toolchain)
+
     args = [
-        "--mxe={}".format(ctx.files._mxe[0].dirname),
+        "--target={}".format(target),
+        "--mxe={}".format(mxe.dirname),
         "--out={}".format(out.path),
     ]
     if ctx.attr.skip_dlls:
@@ -19,7 +37,7 @@ def _pkg_win_impl(ctx):
     ctx.actions.run(
         executable = ctx.executable._tool,
         arguments = args,
-        inputs = ctx.files.srcs + ctx.files._mxe + ctx.files.zips,
+        inputs = ctx.files.srcs + ctx.files.zips + cc_toolchain.all_files.to_list(),
         outputs = [out],
         progress_message = "Packaging files into {}".format(out.basename),
         mnemonic = "PkgWin",
@@ -47,14 +65,16 @@ pkg_win = platform_rule(
             doc = "List of additional ZIP archives to re-pack into this archive",
             allow_files = True,
         ),
-        "_mxe": attr.label(
-            doc = "Location of the MXE toolchain",
-            default = "@gcc_mxe_mingw64_files//:all",
-        ),
         "_tool": attr.label(
             default = "//util:pkg_win",
             cfg = "host",
             executable = True,
         ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
     },
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )

--- a/third_party/mxe/BUILD.mxe_src.bazel
+++ b/third_party/mxe/BUILD.mxe_src.bazel
@@ -12,67 +12,72 @@ filegroup(
     srcs = glob(["**"]),
 )
 
+TARGETS = {
+    "win32": "i686-w64-mingw32.shared",
+    "win64": "x86_64-w64-mingw32.shared",
+}
+
 binaries = [
-    "x86_64-w64-mingw32.shared-addr2line",
-    "x86_64-w64-mingw32.shared-ar",
-    "x86_64-w64-mingw32.shared-as",
-    "x86_64-w64-mingw32.shared-c++",
-    "x86_64-w64-mingw32.shared-c++filt",
-    "x86_64-w64-mingw32.shared-cpp",
-    "x86_64-w64-mingw32.shared-dlltool",
-    "x86_64-w64-mingw32.shared-dllwrap",
-    "x86_64-w64-mingw32.shared-elfedit",
-    "x86_64-w64-mingw32.shared-g++",
-    "x86_64-w64-mingw32.shared-gcc",
-    "x86_64-w64-mingw32.shared-gcc-11.3.0",
-    "x86_64-w64-mingw32.shared-gcc-ar",
-    "x86_64-w64-mingw32.shared-gcc-nm",
-    "x86_64-w64-mingw32.shared-gcc-ranlib",
-    "x86_64-w64-mingw32.shared-gcov",
-    "x86_64-w64-mingw32.shared-gcov-dump",
-    "x86_64-w64-mingw32.shared-gcov-tool",
-    "x86_64-w64-mingw32.shared-gfortran",
-    "x86_64-w64-mingw32.shared-gprof",
-    "x86_64-w64-mingw32.shared-ld",
-    "x86_64-w64-mingw32.shared-ld.bfd",
-    "x86_64-w64-mingw32.shared-lto-dump",
-    "x86_64-w64-mingw32.shared-nm",
-    "x86_64-w64-mingw32.shared-objcopy",
-    "x86_64-w64-mingw32.shared-objdump",
-    "x86_64-w64-mingw32.shared-pkg-config",
-    "x86_64-w64-mingw32.shared-ranlib",
-    "x86_64-w64-mingw32.shared-readelf",
-    "x86_64-w64-mingw32.shared-size",
-    "x86_64-w64-mingw32.shared-strings",
-    "x86_64-w64-mingw32.shared-strip",
-    "x86_64-w64-mingw32.shared-windmc",
-    "x86_64-w64-mingw32.shared-windres",
+    "{prefix}-addr2line",
+    "{prefix}-ar",
+    "{prefix}-as",
+    "{prefix}-c++",
+    "{prefix}-c++filt",
+    "{prefix}-cpp",
+    "{prefix}-dlltool",
+    "{prefix}-dllwrap",
+    "{prefix}-elfedit",
+    "{prefix}-g++",
+    "{prefix}-gcc",
+    "{prefix}-gcc-11.3.0",
+    "{prefix}-gcc-ar",
+    "{prefix}-gcc-nm",
+    "{prefix}-gcc-ranlib",
+    "{prefix}-gcov",
+    "{prefix}-gcov-dump",
+    "{prefix}-gcov-tool",
+    "{prefix}-gfortran",
+    "{prefix}-gprof",
+    "{prefix}-ld",
+    "{prefix}-ld.bfd",
+    "{prefix}-lto-dump",
+    "{prefix}-nm",
+    "{prefix}-objcopy",
+    "{prefix}-objdump",
+    "{prefix}-pkg-config",
+    "{prefix}-ranlib",
+    "{prefix}-readelf",
+    "{prefix}-size",
+    "{prefix}-strings",
+    "{prefix}-strip",
+    "{prefix}-windmc",
+    "{prefix}-windres",
 ]
 
-make(
-    name = "cc",
+[make(
+    name = "cc_{target}".format(target = target),
     args = [
-        "MXE_TARGETS='x86_64-w64-mingw32.shared'",
+        "MXE_TARGETS='{prefix}'".format(prefix = prefix),
     ],
     lib_source = ":all_srcs",
-    out_binaries = binaries,
+    out_binaries = [b.format(prefix = prefix) for b in binaries],
     tags = [
         "no-sandbox",
         "requires-network",
     ],
     targets = ["cc"],
-)
+) for target, prefix in TARGETS.items()]
 
-filegroup(
-    name = "gen_dir",
-    srcs = [":cc"],
+[filegroup(
+    name = "gen_dir_{target}".format(target = target),
+    srcs = [":cc_{target}".format(target = target)],
     output_group = "gen_dir",
-)
+) for target, _ in TARGETS.items()]
 
-pkg_tar(
-    name = "mxe-binaries",
-    srcs = [":gen_dir"],
+[pkg_tar(
+    name = "mxe-binaries-{target}".format(target = target),
+    srcs = [":gen_dir_{target}".format(target = target)],
     extension = "tar.xz",
     package_dir = "mxe",
-    strip_prefix = "external/mxe_src/copy_cc/cc",
-)
+    strip_prefix = "external/mxe_src/copy_cc_{target}/cc_{target}".format(target = target),
+) for target, _ in TARGETS.items()]

--- a/third_party/qemu/repos.bzl
+++ b/third_party/qemu/repos.bzl
@@ -18,8 +18,8 @@ def qemu_src_repos():
 def qemu_binary_repos():
     http_archive(
         name = "qemu",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/qemu-binaries.tar.xz",
-        sha256 = "664525cca6fc5b29b7bcc0af435b7a844b7769852b1ce40e25c9e4c516dd1511",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/qemu-binaries.tar.xz",
+        sha256 = "f80d708c3d34f2a9133b9ada6ac04437af06cf539f3d5ed249a367865dcbab58",
         build_file = Label("//third_party/qemu:BUILD.qemu.bazel"),
         strip_prefix = "qemu",
     )

--- a/third_party/qemu/repos.bzl
+++ b/third_party/qemu/repos.bzl
@@ -18,8 +18,8 @@ def qemu_src_repos():
 def qemu_binary_repos():
     http_archive(
         name = "qemu",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.6/qemu-binaries.tar.xz",
-        sha256 = "4f0af05c5ca356c9463f38c9218be7a452452725248e1731e58a332e12cb7a4b",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/qemu-binaries.tar.xz",
+        sha256 = "664525cca6fc5b29b7bcc0af435b7a844b7769852b1ce40e25c9e4c516dd1511",
         build_file = Label("//third_party/qemu:BUILD.qemu.bazel"),
         strip_prefix = "qemu",
     )

--- a/third_party/qemu/repos.bzl
+++ b/third_party/qemu/repos.bzl
@@ -18,8 +18,8 @@ def qemu_src_repos():
 def qemu_binary_repos():
     http_archive(
         name = "qemu",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/qemu-binaries.tar.xz",
-        sha256 = "f80d708c3d34f2a9133b9ada6ac04437af06cf539f3d5ed249a367865dcbab58",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre3/qemu-binaries.tar.xz",
+        sha256 = "664525cca6fc5b29b7bcc0af435b7a844b7769852b1ce40e25c9e4c516dd1511",
         build_file = Label("//third_party/qemu:BUILD.qemu.bazel"),
         strip_prefix = "qemu",
     )

--- a/toolchains/cc65/repository.bzl
+++ b/toolchains/cc65/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def cc65_repos():
     compiler_repository(
         name = "cc65_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/cc65-binaries.tar.xz",
-        sha256 = "dfeb3eb458c1712cb6896d1484156778681d412df806fdd9a6b762f6772f989c",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre3/cc65-binaries.tar.xz",
+        sha256 = "3e9d26b473f5452a9746189a5b970ffbcd7da36e5d6e5917c035cd2149f64946",
         strip_prefix = "cc65",
     )

--- a/toolchains/cc65/repository.bzl
+++ b/toolchains/cc65/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def cc65_repos():
     compiler_repository(
         name = "cc65_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.6/cc65-binaries.tar.xz",
-        sha256 = "cf666cf5452bf081b68ef9ae2722ce77da0969d075a3633c95b941be08dcd92a",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/cc65-binaries.tar.xz",
+        sha256 = "dfeb3eb458c1712cb6896d1484156778681d412df806fdd9a6b762f6772f989c",
         strip_prefix = "cc65",
     )

--- a/toolchains/cc65/repository.bzl
+++ b/toolchains/cc65/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def cc65_repos():
     compiler_repository(
         name = "cc65_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/cc65-binaries.tar.xz",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/cc65-binaries.tar.xz",
         sha256 = "dfeb3eb458c1712cb6896d1484156778681d412df806fdd9a6b762f6772f989c",
         strip_prefix = "cc65",
     )

--- a/toolchains/gcc_mxe_mingw32/BUILD.bazel
+++ b/toolchains/gcc_mxe_mingw32/BUILD.bazel
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//config:compiler.bzl", "setup")
+load("//platforms/x86_32:windows.bzl", "DEVICES")
+
+package(default_visibility = ["//visibility:public"])
+
+SYSTEM_INCLUDE_PATHS = [
+    "external/gcc_mxe_mingw32_files/lib/gcc/i686-w64-mingw32.shared/11.3.0/include",
+    "external/gcc_mxe_mingw32_files/lib/gcc/i686-w64-mingw32.shared/11.3.0/include-fixed",
+    "external/gcc_mxe_mingw32_files/lib/gcc/i686-w64-mingw32.shared/11.3.0/include/c++",
+    "external/gcc_mxe_mingw32_files/lib/gcc/i686-w64-mingw32.shared/11.3.0/include/c++/backward",
+    "external/gcc_mxe_mingw32_files/lib/gcc/i686-w64-mingw32.shared/11.3.0/include/c++/i686-w64-mingw32.shared",
+    "external/gcc_mxe_mingw32_files/i686-w64-mingw32.shared/include",
+]
+
+filegroup(
+    name = "compiler_components",
+    srcs = [
+        "//toolchains/gcc_mxe_mingw32/wrappers:all",
+        "@gcc_mxe_mingw32_files//:all",
+    ],
+)
+
+[setup(
+    name = device.name,
+    architecture = device.architecture,
+    artifact_naming = device.artifact_naming,
+    compiler_components = ":compiler_components",
+    constraints = device.constraints,
+    feature_set = device.feature_set,
+    include_directories = SYSTEM_INCLUDE_PATHS,
+    params = {
+        "compiler": "gcc",
+    },
+    substitutions = device.substitutions,
+    tools = {
+        "ar": "wrappers/ar",
+        "cpp": "wrappers/cpp",
+        "gcc": "wrappers/gcc",
+        "gcov": "wrappers/gcov",
+        "ld": "wrappers/ld",
+        "nm": "wrappers/nm",
+        "objcopy": "wrappers/objcopy",
+        "objdump": "wrappers/objdump",
+        "strip": "wrappers/strip",
+    },
+) for device in DEVICES]

--- a/toolchains/gcc_mxe_mingw32/repository.bzl
+++ b/toolchains/gcc_mxe_mingw32/repository.bzl
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@crt//config:repo.bzl", "compiler_repository")
+
+def gcc_mxe_mingw32_repos():
+    compiler_repository(
+        name = "gcc_mxe_mingw32_files",
+        archive = Label("//prebuilt:mxe-binaries-win32.tar.xz"),
+        #url = "https://github.com/lowRISC/crt/releases/download/v0.3.6/mxe-binaries-win32.tar.xz",
+        #sha256 = "98a352e7909a154af54f2581fc117e5fe3f4837c6ab20d18fe697bc007dc6017",
+        strip_prefix = "mxe",
+    )

--- a/toolchains/gcc_mxe_mingw32/repository.bzl
+++ b/toolchains/gcc_mxe_mingw32/repository.bzl
@@ -7,8 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw32_repos():
     compiler_repository(
         name = "gcc_mxe_mingw32_files",
-        archive = Label("//prebuilt:mxe-binaries-win32.tar.xz"),
-        #url = "https://github.com/lowRISC/crt/releases/download/v0.3.6/mxe-binaries-win32.tar.xz",
-        #sha256 = "98a352e7909a154af54f2581fc117e5fe3f4837c6ab20d18fe697bc007dc6017",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/mxe-binaries-win32.tar.xz",
+        sha256 = "597e9b082b2fc1f4b34a5f0bd1f0422951b774d727e614b92c636d465d247aa5",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw32/repository.bzl
+++ b/toolchains/gcc_mxe_mingw32/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw32_repos():
     compiler_repository(
         name = "gcc_mxe_mingw32_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/mxe-binaries-win32.tar.xz",
-        sha256 = "597e9b082b2fc1f4b34a5f0bd1f0422951b774d727e614b92c636d465d247aa5",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre3/mxe-binaries-win32.tar.xz",
+        sha256 = "66ffd6eab925557b9a0aa0d7e06350755744819e5a2f81d28a834414c68fff70",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw32/repository.bzl
+++ b/toolchains/gcc_mxe_mingw32/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw32_repos():
     compiler_repository(
         name = "gcc_mxe_mingw32_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/mxe-binaries-win32.tar.xz",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/mxe-binaries-win32.tar.xz",
         sha256 = "597e9b082b2fc1f4b34a5f0bd1f0422951b774d727e614b92c636d465d247aa5",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw32/repository.bzl.template
+++ b/toolchains/gcc_mxe_mingw32/repository.bzl.template
@@ -4,10 +4,10 @@
 
 load("@crt//config:repo.bzl", "compiler_repository")
 
-def gcc_mxe_mingw64_repos():
+def gcc_mxe_mingw32_repos():
     compiler_repository(
-        name = "gcc_mxe_mingw64_files",
-        url = "${BASE_URL}/releases/download/${RELEASE_TAG}/mxe-binaries-win64.tar.xz",
+        name = "gcc_mxe_mingw32_files",
+        url = "${BASE_URL}/releases/download/${RELEASE_TAG}/mxe-binaries-win32.tar.xz",
         sha256 = "${SHA256}",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw32/wrappers/BUILD
+++ b/toolchains/gcc_mxe_mingw32/wrappers/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*"]))
+
+filegroup(
+    name = "all",
+    srcs = [
+        "ar",
+        "cpp",
+        "gcc",
+        "gcov",
+        "ld",
+        "nm",
+        "objcopy",
+        "objdump",
+        "strip",
+    ],
+)

--- a/toolchains/gcc_mxe_mingw32/wrappers/ar
+++ b/toolchains/gcc_mxe_mingw32/wrappers/ar
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/cpp
+++ b/toolchains/gcc_mxe_mingw32/wrappers/cpp
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/driver.sh
+++ b/toolchains/gcc_mxe_mingw32/wrappers/driver.sh
@@ -1,0 +1,25 @@
+#!/bin/bash --norc
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+PROG=${0##*/}
+DRIVER_DIR=${0%/*}
+MXE="gcc_mxe_mingw32_files"
+VERSION="11.3.0"
+PREFIX="i686-w64-mingw32.shared"
+export COMPILER_PATH="external/${MXE}/libexec/gcc/${PREFIX}/${VERSION}:external/${MXE}/bin:${DRIVER_DIR}"
+export LIBRARY_PATH="external/${MXE}/${PREFIX}/lib:external/${MXE}/lib/gcc/${PREFIX}/${VERSION}"
+
+ARGS=()
+POSTARGS=()
+case "${PROG}" in
+    gcc)
+        ARGS+=("-B" "external/${MXE}/bin/${PREFIX}-")
+        ;;
+esac
+
+exec "external/${MXE}/bin/${PREFIX}-${PROG}" \
+    "${ARGS[@]}" \
+    "$@"\
+    "${POSTARGS[@]}"

--- a/toolchains/gcc_mxe_mingw32/wrappers/gcc
+++ b/toolchains/gcc_mxe_mingw32/wrappers/gcc
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/gcov
+++ b/toolchains/gcc_mxe_mingw32/wrappers/gcov
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/ld
+++ b/toolchains/gcc_mxe_mingw32/wrappers/ld
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/nm
+++ b/toolchains/gcc_mxe_mingw32/wrappers/nm
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/objcopy
+++ b/toolchains/gcc_mxe_mingw32/wrappers/objcopy
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/objdump
+++ b/toolchains/gcc_mxe_mingw32/wrappers/objdump
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw32/wrappers/strip
+++ b/toolchains/gcc_mxe_mingw32/wrappers/strip
@@ -1,0 +1,1 @@
+driver.sh

--- a/toolchains/gcc_mxe_mingw64/repository.bzl
+++ b/toolchains/gcc_mxe_mingw64/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw64_repos():
     compiler_repository(
         name = "gcc_mxe_mingw64_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/mxe-binaries-win64.tar.xz",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/mxe-binaries-win64.tar.xz",
         sha256 = "9e5a3e7e315845b0c2a28439420c7e8a236389df0bee9d1a6c8a727096441336",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw64/repository.bzl
+++ b/toolchains/gcc_mxe_mingw64/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw64_repos():
     compiler_repository(
         name = "gcc_mxe_mingw64_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre2/mxe-binaries-win64.tar.xz",
-        sha256 = "9e5a3e7e315845b0c2a28439420c7e8a236389df0bee9d1a6c8a727096441336",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre3/mxe-binaries-win64.tar.xz",
+        sha256 = "97ab7f717b8d6617b31714bbc96629b2035068428ca3520ca9413215b442f9ca",
         strip_prefix = "mxe",
     )

--- a/toolchains/gcc_mxe_mingw64/repository.bzl
+++ b/toolchains/gcc_mxe_mingw64/repository.bzl
@@ -7,7 +7,7 @@ load("@crt//config:repo.bzl", "compiler_repository")
 def gcc_mxe_mingw64_repos():
     compiler_repository(
         name = "gcc_mxe_mingw64_files",
-        url = "https://github.com/lowRISC/crt/releases/download/v0.3.6/mxe-binaries.tar.xz",
-        sha256 = "98a352e7909a154af54f2581fc117e5fe3f4837c6ab20d18fe697bc007dc6017",
+        url = "https://github.com/lowRISC/crt/releases/download/v0.3.7-pre/mxe-binaries-win64.tar.xz",
+        sha256 = "9e5a3e7e315845b0c2a28439420c7e8a236389df0bee9d1a6c8a727096441336",
         strip_prefix = "mxe",
     )

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -9,4 +9,5 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "pkg_win",
     srcs = ["pkg_win.py"],
+    srcs_version = "PY3",
 )

--- a/util/pkg_win.py
+++ b/util/pkg_win.py
@@ -179,7 +179,7 @@ class PkgWin(object):
                 if arch != self.target:
                     logging.warning(
                         'Unexpected target for %r: %s (expected %s)', f,
-                        target, self.target)
+                        arch, self.target)
                 self.detect_dlls(args, f, dlls)
 
         if self.missing_dlls and not args.ignore_missing_dlls:


### PR DESCRIPTION
1. Add build automation to build both Win32 and Win64 versions of the MXE gcc mingw32/64 toolchain.
2. Add a platform configuration for win32: `//platforms/x86_32:win32`.
3. Add a compiler configuration that uses the mingw32 compiler for `x86_32:win32`.
4. Fix the windows packing rules to behave appropriately with respect to the 32- or 64- bit toolchain.