### PR TITLE
Add a unique execution config for `win32`

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -4,10 +4,17 @@
 
 load("//third_party/bazel:deps.bzl", "bazel_deps")
 
-def crt_deps(windows_disk_image = None):
+def crt_deps(
+        win64_disk_image = None,
+        win32_disk_image = None):
     bazel_deps()
-    if windows_disk_image:
+    if win64_disk_image:
         native.bind(
-            name = "windows_disk_image",
-            actual = windows_disk_image,
+            name = "win64_disk_image",
+            actual = win64_disk_image,
+        )
+    if win32_disk_image:
+        native.bind(
+            name = "win32_disk_image",
+            actual = win32_disk_image,
         )

--- a/platforms/x86_32/BUILD.bazel
+++ b/platforms/x86_32/BUILD.bazel
@@ -14,12 +14,12 @@ platform(
     ],
 )
 
-# FIXME: this is an exact copy of //platforms/x86_64:qemu_windows.  This
-# should probably instead reference a disk image that can be an old
-# version of 32-bit windows.
+# This is a near copy of //platforms/x86_64:qemu_windows.
+# This configuration runs the `i386` version of qemu with a 32-bit
+# version of windows.
 exec_config(
     name = "qemu_windows",
-    data = ["//external:windows_disk_image"],
+    data = ["//external:win32_disk_image"],
     params = [
         "-M pc",
         "-m {memory}",
@@ -37,9 +37,9 @@ exec_config(
         "-device pci-serial,chardev=com3",
     ],
     preparation = "windows",
-    program = "@qemu//:qemu-system-x86_64",
+    program = "@qemu//:qemu-system-i386",
     substitutions = {
-        "disk_image": "$(location //external:windows_disk_image)",
+        "disk_image": "$(location //external:win32_disk_image)",
         # You should only use quick_kill if you're using a disk_image_snapshot
         # for the disk image.  Snapshots are discarded on every run, so an
         # improper shutdown doesn't matter.

--- a/platforms/x86_64/BUILD.bazel
+++ b/platforms/x86_64/BUILD.bazel
@@ -16,7 +16,7 @@ platform(
 
 exec_config(
     name = "qemu_windows",
-    data = ["//external:windows_disk_image"],
+    data = ["//external:win64_disk_image"],
     params = [
         "-M pc",
         "-m {memory}",
@@ -36,7 +36,7 @@ exec_config(
     preparation = "windows",
     program = "@qemu//:qemu-system-x86_64",
     substitutions = {
-        "disk_image": "$(location //external:windows_disk_image)",
+        "disk_image": "$(location //external:win64_disk_image)",
         # You should only use quick_kill if you're using a disk_image_snapshot
         # for the disk image.  Snapshots are discarded on every run, so an
         # improper shutdown doesn't matter.

--- a/platforms/x86_64/Windows-Qemu-Test-Setup.md
+++ b/platforms/x86_64/Windows-Qemu-Test-Setup.md
@@ -1,0 +1,151 @@
+# Windows Qemu Test Setup
+
+How to configure windows to run under qemu for test automation.
+
+1. Get a copy of windows install media.
+2. Create a qemu `qcow2` disk image.
+
+   ```
+   qemu-img create -f qcow2 windows.img 10G
+   ```
+
+3. Start qemu and install windows
+
+   NOTE: you can use `qemu-system-i386` if you're installing 32-bit windows.
+
+   ```
+   qemu-system-x86_64 -M pc -m 4G \
+       -usb -device usb-tablet \
+       -hda windows.img \
+       -cdrom ${your_windows_install_iso}
+   ```
+
+   - Set the user name to something like `test_user`.
+   - Set the computer name to something like `test-platform`.
+
+4. After the install completes, shut down and snapshot the disk image.
+
+   This will create a named disk snapshot you can restore in the event
+   you make an error in any of the subsequent steps.
+
+   ```
+   qemu-img snapshot -c post_install windows.img
+   ```
+
+5. Add serial ports and a qemu `vvfat` disk and install additional drivers.
+
+   The CRT test rules will use the emulated PC's com ports to communicate
+   the stdout and stderr streams and the exit code.  The test rules will
+   use the `vvfat` disk to inject the test programs into the windows VM.
+
+   NOTE: The file `qemupciserial.inf` comes from the qemu repository.  You
+   will need this file so that Windows will recognize the `com3:` device. 
+   Installation of drivers from `inf` files has changed over the years; in
+   Windows 7, you'll need to use Device Manager to install this driver.
+
+
+   ```
+   # This is just a temporary path for the vvfat disk and
+   # com-port files.  Test automation will create these paths
+   # when running a test.
+   mkdir -p /tmp/qemu/disk
+   cp ${qemu}/docs/qemupciserial.inf /tmp/qemu/disk
+   
+   qemu-system-x86_64 -M pc -m 4G \
+       -usb -device usb-tablet \
+       -hda windows.img \
+       -drive file=fat:rw:/tmp/qemu/disk,format=raw \
+       -chardev file,id=com3,path=/tmp/qemu/exitcode \
+       -serial file:/tmp/qemu/stdout \
+       -serial file:/tmp/qemu/stderr \
+       -device pci-serial,chardev=com3
+   
+   # Once you've installed the driver software. Shutdown and snapshot:
+   qemu-img snapshot -c drivers windows.img
+   ```
+
+6. Enable auto-login for your test user.
+
+   - For Windows 7:
+      - Start the VM.
+      - Run `control userpasswords2`
+      - Select the `test_user` account.
+      - Clear the "Users must enter a user name and password" checkbox.
+      - Apply.  Enter the password.
+      - Shutdown/Restart and confirm auto-login.
+      - Shutdown and make a disk snapshot.
+        ```
+        qemu-img snapshot -c autologin windows.img
+        ```
+
+7. Create an auto-run script that will execute the bazel-injected tests.
+
+   - Start the VM.
+   - Open the `All Programs | Startup` folder.
+   - Create a file named `run.bat` with the following contents:
+     ```
+     e:
+     __test__.bat
+     ```
+   - Shutdown/Restart and confirm that `run.bat` executes.
+   - Shutdown and make a disk snapshot.
+     ```
+     qemu-img snapshot -c autorun windows.img
+     ```
+
+8. In the same directory as your `windows.img` add a workspace configuration.
+
+- `WORKSPACE.bazel`:
+   ```
+   workspace(name = "prebuilt")
+   ```
+
+- `BUILD.bazel`:
+   ```
+   package(default_visibility = ["//visibility:public"])
+   
+   exports_files(glob(["**"]))
+   
+   ```
+
+9. In the repository where you want to create tests for windows binaries:
+
+- `WORKSPACE.bazel`:
+   ```
+   local_repository(
+       name = "prebuilt",
+       path = "/path/to/your/prebuild/subdir"
+   )
+   
+   # And, when you call `crt_deps`, tell it about your disk images
+   # You may specify either `win64_disk_image` or `win32_disk_image` (or both).
+   crt_deps(
+       win64_disk_image = "@prebuilt//:windows64.img",
+       win32_disk_image = "@prebuilt//:windows32.img",
+   )
+   ```
+
+- To define a test, in a BUILD file:
+
+   ```
+   load("@crt//rules:run.bzl", "platform_test")
+   
+   platform_test(
+       name = "some_windows_test",
+       binary = ":some_cc_test_label",
+   
+       # Available windows execution platforms:
+       # - @crt//platforms/x86_64:qemu_windows - Execute on 64-bit windows.
+       # - @crt//platforms/x86_32:qemu_windows - Execute on 32-bit windows.
+       exec_config = "@crt//platforms/x86_64:qemu_windows",
+   
+       # Available windows build platforms:
+       # - @crt//platforms/x86_64:win64 - Modern 64-bit Windows.
+       # - @crt//platforms/x86_32:win32 - Legacy 32-bit Windows.
+       platform = "@crt//platforms/x86_64:win64",
+   
+       # Optional: if you say `local=True`, a qemu window will open
+       # and display the VM's console/gui.
+       local = True,
+   )
+   ```

--- a/third_party/qemu/BUILD.qemu.bazel
+++ b/third_party/qemu/BUILD.qemu.bazel
@@ -15,6 +15,14 @@ filegroup(
 )
 
 filegroup(
+    name = "qemu-system-i386",
+    srcs = ["bin/qemu-system-i386"],
+    data = glob(["share/qemu/**"]) + [
+        "bin/qemu-img",
+    ],
+)
+
+filegroup(
     name = "qemu-system-arm",
     srcs = ["bin/qemu-system-arm"],
 )


### PR DESCRIPTION
1. Add an execution config for `win32` that is distinct from `win64`.
2. Document how to create and use Windows disk images for testing.

Signed-off-by: Chris Frantz <cfrantz@google.com>