### PR TITLE
Make builds hermetic for win32

### DIFF
--- a/features/windows/BUILD.bazel
+++ b/features/windows/BUILD.bazel
@@ -45,10 +45,55 @@ feature(
     ],
 )
 
+feature(
+    name = "opt",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-O2",
+                        "-finline-small-functions",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
+    name = "reproducible",
+    enabled = True,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = ["-Werror=date-time"],
+                ),
+            ],
+        ),
+        flag_set(
+            actions = LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Wl,--no-insert-timestamp",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
 feature_set(
     name = "windows",
     base = ["//features/common"],
     feature = [
         ":default_link_flags",
+        ":opt",
+        ":reproducible",
     ],
 )


### PR DESCRIPTION
1. Don't place the timestamp in the PE-COFF header.
2. Disable LTO for windows `opt` builds.

Signed-off-by: Chris Frantz <cfrantz@google.com>