### PR TITLE
Update lowRISC toolchain version to 20230427-1

### DIFF
--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -46,6 +46,7 @@ feature(
                     flags = [
                         "-Os",
                         "-g",
+                        "-gdwarf-4",
                     ],
                 ),
             ],

--- a/toolchains/lowrisc_rv32imcb/BUILD.bazel
+++ b/toolchains/lowrisc_rv32imcb/BUILD.bazel
@@ -8,7 +8,7 @@ load("//platforms/riscv32:devices.bzl", "DEVICES")
 package(default_visibility = ["//visibility:public"])
 
 SYSTEM_INCLUDE_PATHS = [
-    "external/lowrisc_rv32imcb_files/lib/clang/13.0.1/include",
+    "external/lowrisc_rv32imcb_files/lib/clang/16/include",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0",
     "external/lowrisc_rv32imcb_files/riscv32-unknown-elf/include/c++/10.2.0/backward",

--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -8,8 +8,8 @@ def lowrisc_rv32imcb_repos(local = None):
     http_archive_or_local(
         name = "lowrisc_rv32imcb_files",
         local = local,
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20230228-1/lowrisc-toolchain-rv32imcb-20230228-1.tar.xz",
-        sha256 = "c28ad597d0a26f03513c4d9feaa6c8c536548112142b355987b6c465d072cc35",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-20230228-1",
+        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20230427-1/lowrisc-toolchain-rv32imcb-20230427-1.tar.xz",
+        sha256 = "ac9d986d1d7a8edf920d3d6b14629517752b6818b8401fb3dfee78d05bf79f2f",
+        strip_prefix = "lowrisc-toolchain-rv32imcb-20230427-1",
         build_file = Label("//toolchains:BUILD.export_all.bazel"),
     )


### PR DESCRIPTION
The toolchain release 20230427-1 updates Clang/LLVM to LLVM 16.0.2, plus support for:

 - hardening patches.
 - unratified bitmanip extensions.
 - `.option arch` assembly directive.