### PR TITLE
Enable RISC-V ratified bitmanip extensions

### DIFF
--- a/platforms/riscv32/devices.bzl
+++ b/platforms/riscv32/devices.bzl
@@ -7,14 +7,14 @@ load("//config:device.bzl", "device_config")
 DEVICES = [
     device_config(
         name = "opentitan",
-        architecture = "rv32imc",
-        feature_set = "//platforms/riscv32/features:rv32imc-hardened",
+        architecture = "rv32imc_zba_zbb_zbc_zbs",
+        feature_set = "//platforms/riscv32/features:rv32imcb-hardened",
         constraints = [
             "@platforms//cpu:riscv32",
             "@platforms//os:none",
         ],
         substitutions = {
-            "ARCHITECTURE": "rv32imc",
+            "ARCHITECTURE": "rv32imc_zba_zbb_zbc_zbs",
             "ABI": "ilp32",
             "CMODEL": "medany",
             "ENDIAN": "little",

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -119,7 +119,7 @@ feature(
 )
 
 feature_set(
-    name = "rv32imc",
+    name = "rv32imcb",
     base = [
         "//features/common",
         "//features/embedded",
@@ -133,9 +133,9 @@ feature_set(
 )
 
 feature_set(
-    name = "rv32imc-hardened",
+    name = "rv32imcb-hardened",
     base = [
-        ":rv32imc",
+        ":rv32imcb",
     ],
     feature = [
         ":guards",


### PR DESCRIPTION
This enables the bit manipulation extensions Zba, Zbb, Zbc, and Zbs.