### PR TITLE
Revert "Enable RISC-V ratified bitmanip extensions"

### DIFF
--- a/platforms/riscv32/devices.bzl
+++ b/platforms/riscv32/devices.bzl
@@ -7,14 +7,14 @@ load("//config:device.bzl", "device_config")
 DEVICES = [
     device_config(
         name = "opentitan",
-        architecture = "rv32imc_zba_zbb_zbc_zbs",
-        feature_set = "//platforms/riscv32/features:rv32imcb-hardened",
+        architecture = "rv32imc",
+        feature_set = "//platforms/riscv32/features:rv32imc-hardened",
         constraints = [
             "@platforms//cpu:riscv32",
             "@platforms//os:none",
         ],
         substitutions = {
-            "ARCHITECTURE": "rv32imc_zba_zbb_zbc_zbs",
+            "ARCHITECTURE": "rv32imc",
             "ABI": "ilp32",
             "CMODEL": "medany",
             "ENDIAN": "little",

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -119,7 +119,7 @@ feature(
 )
 
 feature_set(
-    name = "rv32imcb",
+    name = "rv32imc",
     base = [
         "//features/common",
         "//features/embedded",
@@ -133,9 +133,9 @@ feature_set(
 )
 
 feature_set(
-    name = "rv32imcb-hardened",
+    name = "rv32imc-hardened",
     base = [
-        ":rv32imcb",
+        ":rv32imc",
     ],
     feature = [
         ":guards",


### PR DESCRIPTION
Reverts lowRISC/crt#18

I'm reverting this because @luismarques told me this commit causes test failures in OpenTitan. It enables bitmanip unconditionally, but Englishbreakfast doesn't support bitmanip.