### PR TITLE
Bitmanip feature

### DIFF
--- a/config/features.bzl
+++ b/config/features.bzl
@@ -8,8 +8,11 @@ load(
     __feature = "feature",
     __flag_group = "flag_group",
     __flag_set = "flag_set",
+    __with_feature_set = "with_feature_set",
 )
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+with_feature_set = __with_feature_set
 
 CPP_ALL_COMPILE_ACTIONS = [
     ACTION_NAMES.assemble,
@@ -68,6 +71,17 @@ def reify_flag_group(
         expand_if_equal,
     )
 
+def reify_with_features_set(
+        features,
+        not_features,
+        type_name):
+    if type_name != "with_feature_set":
+        fail("the argument to with_features must be an array of values created by with_feature_set")
+    return with_feature_set(
+        features,
+        not_features
+    )
+
 def reify_flag_set(
         actions = [],
         with_features = [],
@@ -75,7 +89,7 @@ def reify_flag_set(
         type_name = None):
     return __flag_set(
         actions,
-        with_features,  # TODO: fix this
+        with_features =[reify_with_features_set(**v) for v in with_features],
         flag_groups = [reify_flag_group(**v) for v in flag_groups],
     )
 

--- a/platforms/riscv32/devices.bzl
+++ b/platforms/riscv32/devices.bzl
@@ -7,14 +7,15 @@ load("//config:device.bzl", "device_config")
 DEVICES = [
     device_config(
         name = "opentitan",
-        architecture = "rv32imc",
-        feature_set = "//platforms/riscv32/features:rv32imc-hardened",
+        architecture = "rv32imc_zba_zbb_zbc_zbs",
+        feature_set = "//platforms/riscv32/features:rv32imcb-hardened",
         constraints = [
             "@platforms//cpu:riscv32",
             "@platforms//os:none",
         ],
         substitutions = {
-            "ARCHITECTURE": "rv32imc",
+            "ARCHITECTURE_WITH_BITMANIP": "rv32imc_zba_zbb_zbc_zbs",
+            "ARCHITECTURE_WITHOUT_BITMANIP": "rv32imc",
             "ABI": "ilp32",
             "CMODEL": "medany",
             "ENDIAN": "little",

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -11,6 +11,7 @@ load(
     "feature_set",
     "flag_group",
     "flag_set",
+    "with_feature_set",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -19,12 +20,37 @@ feature(
     name = "architecture",
     enabled = True,
     flag_sets = [
+        # This set of flag only activates if :rv32_bitmanip is enabled.
         flag_set(
+            with_features = [
+                with_feature_set(
+                    features = ['rv32_bitmanip'],
+                ),
+            ],
             actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS + LD_ALL_ACTIONS,
             flag_groups = [
                 flag_group(
                     flags = [
-                        "-march=ARCHITECTURE",
+                        "-march=ARCHITECTURE_WITH_BITMANIP",
+                        "-mabi=ABI",
+                        "-mcmodel=CMODEL",
+                        "-mENDIAN-endian",
+                    ],
+                ),
+            ],
+        ),
+        # This set of flag only activates if :rv32_bitmanip is NOT enabled.
+        flag_set(
+            with_features = [
+                with_feature_set(
+                    not_features = ['rv32_bitmanip'],
+                ),
+            ],
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS + LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-march=ARCHITECTURE_WITHOUT_BITMANIP",
                         "-mabi=ABI",
                         "-mcmodel=CMODEL",
                         "-mENDIAN-endian",
@@ -33,6 +59,11 @@ feature(
             ],
         ),
     ],
+)
+
+feature(
+    name = 'rv32_bitmanip',
+    enabled = True,
 )
 
 feature(
@@ -94,18 +125,6 @@ feature(
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = CPP_ALL_COMPILE_ACTIONS,
-            flag_groups = [
-                flag_group(
-                    flags = [
-                        "-march=ARCHITECTURE",
-                        "-mabi=ABI",
-                        "-mcmodel=CMODEL",
-                    ],
-                ),
-            ],
-        ),
-        flag_set(
             actions = LD_ALL_ACTIONS,
             flag_groups = [
                 flag_group(
@@ -119,7 +138,7 @@ feature(
 )
 
 feature_set(
-    name = "rv32imc",
+    name = "rv32imcb",
     base = [
         "//features/common",
         "//features/embedded",
@@ -129,13 +148,14 @@ feature_set(
         ":all_warnings_as_errors",
         ":fastbuild",
         ":sys_spec",
+        ":rv32_bitmanip",
     ],
 )
 
 feature_set(
-    name = "rv32imc-hardened",
+    name = "rv32imcb-hardened",
     base = [
-        ":rv32imc",
+        ":rv32imcb",
     ],
     feature = [
         ":guards",


### PR DESCRIPTION
This PR allows the riscv32 platform to be used with or without bitmanip. It uses a feature flag for this (see commit).