### PR TITLE
Enable C/C++ warnings by default

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -54,7 +54,6 @@ feature_single_flag_c_cpp(
 
 feature_single_flag_c_cpp(
     name = "extra_warnings",
-    enabled = False,
     flag = "-Wextra",
 )
 
@@ -65,61 +64,51 @@ feature_single_flag_c_cpp(
 
 feature_single_flag_c_cpp(
     name = "clang_covered_switch_default_warnings",
-    enabled = False,
     flag = "-Wno-covered-switch-default",
 )
 
 feature_single_flag_c_cpp(
     name = "implicit_conversion_warnings",
-    enabled = False,
     flag = "-Wconversion",
 )
 
 feature_single_flag_c_cpp(
     name = "implicit_fallthrough_warnings",
-    enabled = False,
     flag = "-Wimplicit-fallthrough",
 )
 
 feature_single_flag_c_cpp(
     name = "invalid_pch_warnings",
-    enabled = False,
     flag = "-Winvalid-pch",
 )
 
 feature_single_flag_c_cpp(
     name = "strict_prototypes_warnings",
-    enabled = False,
     flag = "-Wstrict-prototypes",
 )
 
 feature_single_flag_c_cpp(
     name = "switch_default_warnings",
-    enabled = False,
     flag = "-Wswitch-default",
 )
 
 feature_single_flag_c_cpp(
     name = "no_missing_field_initializers_warning",
-    enabled = False,
     flag = "-Wno-missing-field-initializers",
 )
 
 feature_single_flag_c_cpp(
     name = "no_sign_compare_warning",
-    enabled = False,
     flag = "-Wno-sign-compare",
 )
 
 feature_single_flag_c_cpp(
     name = "no_unused_function_warning",
-    enabled = False,
     flag = "-Wno-error=unused-function",
 )
 
 feature_single_flag_c_cpp(
     name = "no_unused_parameter_warning",
-    enabled = False,
     flag = "-Wno-unused-parameter",
 )
 

--- a/features/embedded/BUILD.bazel
+++ b/features/embedded/BUILD.bazel
@@ -90,19 +90,16 @@ feature(
 
 feature_single_flag_c_cpp(
     name = "clang_gnu_warnings",
-    enabled = False,
     flag = "-Wgnu",
 )
 
 feature_single_flag_c_cpp(
     name = "no_gnu_zero_variadic_macro_arguments_warning",
-    enabled = False,
     flag = "-Wno-gnu-zero-variadic-macro-arguments",
 )
 
 feature_single_flag_c_cpp(
     name = "no_gnu_statement_expression_from_macro_expansion",
-    enabled = False,
     flag = "-Wno-gnu-statement-expression-from-macro-expansion",
 )
 

--- a/tests/arm/notmain.c
+++ b/tests/arm/notmain.c
@@ -10,7 +10,8 @@ void print_integer(int val) {
         int digit = val % 10;
         val = val / 10;
 
-        *--b = digit < 10 ? '0'+digit : 'A'+digit-10;
+        char digit_char = (char)digit;
+        *--b = digit_char < 10 ? '0'+digit_char: 'A'+digit_char-10;
     }
     while (b < buf+sizeof(buf)) {
         PUT32(UART0BASE+0x00, *b++);

--- a/tests/riscv32/notmain.c
+++ b/tests/riscv32/notmain.c
@@ -31,7 +31,8 @@ void print_integer(int val) {
         int digit = val % 10;
         val = val / 10;
 
-        *--b = digit < 10 ? '0'+digit : 'A'+digit-10;
+        char digit_char = (char)digit;
+        *--b = digit_char < 10 ? '0'+digit_char: 'A'+digit_char-10;
     }
     while (b < buf+sizeof(buf)) {
         uart_putc(*b++);

--- a/tests/windows/sieve.c
+++ b/tests/windows/sieve.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include "lib/sieve.h"
 
-int main() {
+int main(void) {
     sieve();
 
     for(int i=0; i<SIEVE_SZ; i++) {

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -4,4 +4,4 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files("BUILD.export_all.bazel")
+exports_files(["BUILD.export_all.bazel"])

--- a/toolchains/gcc_arm_none_eabi/repository.bzl
+++ b/toolchains/gcc_arm_none_eabi/repository.bzl
@@ -11,4 +11,5 @@ def gcc_arm_none_eabi_repos(local = None):
         url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
         build_file = Label("//toolchains:BUILD.export_all.bazel"),
+        sha256 = "97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3",
     )


### PR DESCRIPTION
This should be a no-op with respect to OpenTitan's compiler flags.

The features added by PR #19 were disabled by default and manually enabled in OpenTitan's .bazelrc file (lowRISC/opentitan#18679). This commit enables those features by default.

(This is the final task in lowRISC/opentitan#12553.)

This PR also makes a few minor fixes:

* Fixes compiler errors in //tests. These were not errors prior to enabling Bazel features by default.
* Fixes a syntax error in //toolchains that prevented `bazel query` from functioning in this repo.
* Adds a sha256 value to the definition of `@gcc_arm_none_eabi_files`.