### PR TITLE
[transition] Remove useless configuration on rule attribute

### DIFF
--- a/rules/transition.bzl
+++ b/rules/transition.bzl
@@ -28,7 +28,7 @@ def platform_rule(**kwargs):
     )
 
 def _platform_target_impl(ctx):
-    info = ctx.attr.target[0][DefaultInfo]
+    info = ctx.attr.target[DefaultInfo]
     return [
         DefaultInfo(
             files = info.files,
@@ -39,6 +39,6 @@ def _platform_target_impl(ctx):
 platform_target = platform_rule(
     implementation = _platform_target_impl,
     attrs = {
-        "target": attr.label(cfg = platform_transition),
+        "target": attr.label(),
     },
 )


### PR DESCRIPTION
The `platform_target` rule is already created using `rv_rule` which sets the `cfg` attribute to make a platform transition on the outgoing edges of the rule. Therefore it is redundant to further make the `target` incoming edge of the rule also transition the platform. For some reason, `attr.label` will make `crt.attr.target` an array when `cfg` is set instead of just a single element. I could not find why in the bazel documentation.