### PR TITLE
[bazel] Fix local_archive to use a string instead of a label

### DIFF
--- a/rules/local_archive.bzl
+++ b/rules/local_archive.bzl
@@ -18,7 +18,7 @@ def _local_archive_impl(rctx):
 local_archive = repository_rule(
     implementation = _local_archive_impl,
     attrs = {
-        "path": attr.label(doc = "Local path to the archive", allow_single_file = True, mandatory = True),
+        "path": attr.string(doc = "Local path to the archive", mandatory = True),
         "strip_prefix": attr.string(doc = "Strip path prefixes when unarchiving"),
         "build_file": attr.label(doc = "A file to use as a BUILD file for this repository", allow_single_file = True),
         "build_file_content": attr.string(doc = "The content for the BUILD file for this repository"),


### PR DESCRIPTION
If one wants to use local_archive with a file path outside of the repository, a label is not ideal because we cannot use absolute file path (they will be interpreted as a target). This makes local_archive (and therefore http_archive_or_local with `local = /home/dev/bla/archive.tar.gz`) essentially unusable.