### PR TITLE
[riscv32] make fastbuild and opt the same

### DIFF
--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -87,6 +87,26 @@ feature(
 )
 
 feature(
+    name = "opt",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Os",
+                        "-g",
+                        "-gdwarf-4",
+                    ],
+                ),
+            ],
+        ),
+    ],
+    provides = ["compilation_mode"],
+)
+
+feature(
     name = "guards",
     enabled = False,
     flag_sets = [
@@ -147,6 +167,7 @@ feature_set(
         ":architecture",
         ":all_warnings_as_errors",
         ":fastbuild",
+        ":opt",
         ":sys_spec",
         ":rv32_bitmanip",
     ],


### PR DESCRIPTION
This makes the fastbuild and opt build configurations the same, since the `rust_binary` rule in `rules_rust` invokes the opt configuration on data deps.