### PR TITLE
Add -Wtype-limits feature

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -112,6 +112,11 @@ feature_single_flag_c_cpp(
     flag = "-Wno-unused-parameter",
 )
 
+feature_single_flag_c_cpp(
+    name = "type_limits_warning",
+    flag = "-Wtype-limits",
+)
+
 feature(
     name = "reproducible",
     enabled = True,


### PR DESCRIPTION
This flag catches easy to miss cases like this:

```c
for (uint8_t i = 5; i >= 0; --i) {
  printf("hello!\n");
}
```

where a `uint8_t` will always be `>= 0`:

```console
[jw type-limits]$ clang -Wtype-limits main.c    
main.c:5:25: warning: result of comparison of unsigned expression >= 0 is always true [-Wtautological-unsigned-zero-compare]
  for (uint8_t i = 5; i >= 0; --i) {
                      ~ ^  ~
```

GCC includes this in `-Wextra`, but surprisingly Clang doesn't even include it in `-Wpedantic` at the moment and you have to go all the way up to `-Weverything`.

I haven't tested this because I can't get the CRT repo to build at the moment, but maybe it's simple enough.