### PR TITLE
Update LLVM version with fixes

### DIFF
--- a/toolchains/lowrisc_rv32imcb/repository.bzl
+++ b/toolchains/lowrisc_rv32imcb/repository.bzl
@@ -8,8 +8,8 @@ def lowrisc_rv32imcb_repos(local = None):
     http_archive_or_local(
         name = "lowrisc_rv32imcb_files",
         local = local,
-        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20230519-1/lowrisc-toolchain-rv32imcb-20230519-1.tar.xz",
-        sha256 = "08b1ba2089aa4206efdca93b7ab70152c3fe16ef4c6ee112a4f35ee3dc65aa8c",
-        strip_prefix = "lowrisc-toolchain-rv32imcb-20230519-1",
+        url = "https://github.com/lowRISC/lowrisc-toolchains/releases/download/20240206-1/lowrisc-toolchain-rv32imcb-20240206-1.tar.xz",
+        sha256 = "7bd480f95c9e2b1161136b2e28b45ac1eb151444b3c0ec4b6db149533da82ba2",
+        strip_prefix = "lowrisc-toolchain-rv32imcb-20240206-1",
         build_file = Label("//toolchains:BUILD.export_all.bazel"),
     )


### PR DESCRIPTION
This version of LLVM includes:

- Updated ePIC GPRel/PCRel rewrite rule to match the latest proposal.
- Backport LLD patches necessary for LTO and ePIC.
- Backport fix for incorrect debug info when linker relaxations are enabled.