### PR TITLE
Enable unused parameter / variable compiler warnings

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -113,6 +113,26 @@ feature_single_flag_c_cpp(
 )
 
 feature_single_flag_c_cpp(
+    name = "unused_parameter_warning",
+    flag = "-Wunused-parameter",
+)
+
+feature_single_flag_c_cpp(
+    name = "unused_warning",
+    flag = "-Wunused",
+)
+
+feature_single_flag_c_cpp(
+    name = "no_unused_parameter_error",
+    flag = "-Wno-error=unused-parameter",
+)
+
+feature_single_flag_c_cpp(
+    name = "no_unused_error",
+    flag = "-Wno-error=unused",
+)
+
+feature_single_flag_c_cpp(
     name = "type_limits_warning",
     flag = "-Wtype-limits",
 )
@@ -316,7 +336,10 @@ feature_set(
         ":no_missing_field_initializers_warning",
         ":no_sign_compare_warning",
         ":no_unused_function_warning",
-        ":no_unused_parameter_warning",
+        ":unused_parameter_warning",
+        ":unused_warning",
+        ":no_unused_parameter_error",
+        ":no_unused_error",
         ":reproducible",
         ":exceptions",
         ":use_lld",


### PR DESCRIPTION
Related to https://github.com/lowRISC/opentitan/pull/23358 and https://github.com/lowRISC/opentitan/issues/22928.

This commit enables the compiler warning to give some signal of potential bugs.

We still have many variables across the repo that are not marked with `OT_DISCARD` explicitly, so this change only enables warning, but not enforcing with error.