### PR TITLE
[features,pkg_win] fix feature and toolchain resolution bugs

### DIFF
--- a/config/features.bzl
+++ b/config/features.bzl
@@ -79,7 +79,7 @@ def reify_with_features_set(
         fail("the argument to with_features must be an array of values created by with_feature_set")
     return with_feature_set(
         features,
-        not_features
+        not_features,
     )
 
 def reify_flag_set(
@@ -89,7 +89,7 @@ def reify_flag_set(
         type_name = None):
     return __flag_set(
         actions,
-        with_features =[reify_with_features_set(**v) for v in with_features],
+        with_features = [reify_with_features_set(**v) for v in with_features],
         flag_groups = [reify_flag_group(**v) for v in flag_groups],
     )
 
@@ -183,14 +183,14 @@ feature = rule(
     provides = [FeatureInfo],
 )
 
-def feature_single_flag_c_cpp(name, flag, enabled = True):
+def feature_single_flag_c_cpp(name, flag, c_only = False, enabled = True):
     """This macro produces a C/C++ feature() that enables a single flag."""
     feature(
         name = name,
         enabled = enabled,
         flag_sets = [
             flag_set(
-                actions = CPP_ALL_COMPILE_ACTIONS + C_ALL_COMPILE_ACTIONS,
+                actions = C_ALL_COMPILE_ACTIONS + ([] if c_only else CPP_ALL_COMPILE_ACTIONS),
                 flag_groups = [
                     flag_group(
                         flags = [flag],

--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -84,6 +84,7 @@ feature_single_flag_c_cpp(
 
 feature_single_flag_c_cpp(
     name = "strict_prototypes_warnings",
+    c_only = True,
     flag = "-Wstrict-prototypes",
 )
 
@@ -174,7 +175,7 @@ feature(
             flag_groups = [
                 flag_group(
                     flags = [
-                        "-flto"
+                        "-flto",
                     ],
                 ),
             ],

--- a/rules/pkg_win.bzl
+++ b/rules/pkg_win.bzl
@@ -20,7 +20,8 @@ def _pkg_win_impl(ctx):
     else:
         fail("Unknown platform:", ctx.attr.platform)
 
-    cc_toolchain = find_cc_toolchain(ctx)
+    toolchain = find_cc_toolchain(ctx)
+    cc_toolchain = getattr(toolchain, "cc", toolchain)
     mxe = _get_toolchain_dir(cc_toolchain)
 
     args = [

--- a/third_party/bazel/repos.bzl
+++ b/third_party/bazel/repos.bzl
@@ -10,10 +10,10 @@ def bazel_repos():
         http_archive,
         name = "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
         ],
-        sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     )
 
     maybe(


### PR DESCRIPTION
This PR contains three commits that:
1. updates the `platforms` dep from 0.0.5 to 0.0.10,
2. enables CC toolchain resolution across older and newer versions of Bazel which are used across lowRISC repos, and
3. enables distinguishing between C-only and C/C++ features, and fixes the `-Wstrict-prototypes` warning to only apply to C code, not C++ code (as specified by https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstrict-prototypes)
