### PR TITLE
[features] Add feature for Oz minsize opt level

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -184,6 +184,25 @@ feature(
 )
 
 feature(
+    name = "minsize",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = C_ALL_COMPILE_ACTIONS + CPP_ALL_COMPILE_ACTIONS + LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Oz",
+                        # Inline slightly more which is actually smaller.
+                        "-mllvm", "--inline-threshold=10",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
     name = "symbol_garbage_collection",
     enabled = True,
     flag_sets = [
@@ -322,6 +341,7 @@ feature_set(
         ":exceptions",
         ":use_lld",
         ":lto",
+        ":minsize",
         ":symbol_garbage_collection",
         ":dbg",
         ":fastbuild",


### PR DESCRIPTION
When enabling LTO, Oz is required to have a smaller firmware size.

This PR adds the "minsize" feature, which will be enabled along with LTO on some ROM_EXT targets through bazel transition.

In our tests with ROM_EXT on the master branch,
* `Os + LTO` ~ +2,904 bytes
* `Oz      ` ~ -1,260 bytes
* `Oz + LTO` ~ -1,640 bytes