### PR TITLE
[features] Fix minsize feature list order

### DIFF
--- a/features/common/BUILD.bazel
+++ b/features/common/BUILD.bazel
@@ -208,13 +208,11 @@ feature(
     enabled = False,
     flag_sets = [
         flag_set(
-            actions = C_ALL_COMPILE_ACTIONS + CPP_ALL_COMPILE_ACTIONS + LD_ALL_ACTIONS,
+            actions = C_ALL_COMPILE_ACTIONS + CPP_ALL_COMPILE_ACTIONS,
             flag_groups = [
                 flag_group(
                     flags = [
                         "-Oz",
-                        # Inline slightly more which is actually smaller.
-                        "-mllvm", "--inline-threshold=10",
                     ],
                 ),
             ],
@@ -364,11 +362,15 @@ feature_set(
         ":exceptions",
         ":use_lld",
         ":lto",
-        ":minsize",
         ":symbol_garbage_collection",
         ":dbg",
         ":fastbuild",
         ":opt",
+
+        # To overwrite the level to minsize with feature flags, it needs to be
+        # listed after the compilation modes.
+        ":minsize",
+
         ":output_format",
         ":misc",
         ":coverage",

--- a/platforms/riscv32/features/BUILD.bazel
+++ b/platforms/riscv32/features/BUILD.bazel
@@ -107,6 +107,36 @@ feature(
 )
 
 feature(
+    name = "minsize",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = C_ALL_COMPILE_ACTIONS + CPP_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-Oz",
+                        # Inline slightly more which is actually smaller.
+                        "-mllvm", "--inline-threshold=10",
+                    ],
+                ),
+            ],
+        ),
+        flag_set(
+            actions = LD_ALL_ACTIONS,
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        # Inline slightly more which is actually smaller.
+                        "-Wl,-mllvm", "-Wl,--inline-threshold=10",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+feature(
     name = "guards",
     enabled = False,
     flag_sets = [
@@ -168,6 +198,7 @@ feature_set(
         ":all_warnings_as_errors",
         ":fastbuild",
         ":opt",
+        ":minsize",
         ":sys_spec",
         ":rv32_bitmanip",
     ],


### PR DESCRIPTION
Only the last optimization level is effective.

To overwrite the level to Oz with the minsize feature flag, the feature needs to be listed after the compilation modes.